### PR TITLE
Add environment variable template

### DIFF
--- a/powerlifting-tracker/.env.example
+++ b/powerlifting-tracker/.env.example
@@ -1,0 +1,8 @@
+# Server configuration
+PORT=5001
+DATABASE_URL="file:./dev.db"
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=30d
+
+# Client configuration
+REACT_APP_API_URL=http://localhost:5001/api


### PR DESCRIPTION
## Summary
- add `.env.example` with server and client environment variables

## Testing
- `npx prisma migrate dev --name init`
- `npm run build` (client)

------
https://chatgpt.com/codex/tasks/task_e_68421ff9688c83308edca377a25366de